### PR TITLE
♻️refactor: 관리자용 재생성 배치 실패 동화 조회 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
 	// Korean text processing
 	implementation 'org.openkoreantext:open-korean-text:2.1.0'
 
+	// retry
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 	// WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.2.12.Final:osx-aarch_64'
 
 	// okhttp
 	implementation 'com.squareup.okhttp3:okhttp:4.11.0'

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -2,6 +2,7 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -9,6 +10,7 @@ import java.util.TimeZone;
 
 @EnableAsync
 @EnableScheduling
+@EnableRetry
 @SpringBootApplication
 public class DemoApplication {
 

--- a/src/main/java/com/example/demo/domain/conversation/event/ConversationNextStoryEventHandler.java
+++ b/src/main/java/com/example/demo/domain/conversation/event/ConversationNextStoryEventHandler.java
@@ -5,11 +5,11 @@ import com.example.demo.apiPayload.status.ErrorStatus;
 import com.example.demo.domain.conversation.entity.SessionStep;
 import com.example.demo.domain.conversation.repository.SessionStepRepository;
 import com.example.demo.domain.conversation.service.model.llm.LlmClient;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.event.TransactionPhase;
 
@@ -23,7 +23,7 @@ public class ConversationNextStoryEventHandler {
     private final SessionStepRepository stepRepo;
     private final LlmClient llmClient;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(ConversationNextStoryEvent event) {
 

--- a/src/main/java/com/example/demo/domain/conversation/event/PageImageEventHandler.java
+++ b/src/main/java/com/example/demo/domain/conversation/event/PageImageEventHandler.java
@@ -20,12 +20,12 @@ public class PageImageEventHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePageImageStarted(StartPageImageEvent event) {
-        conversationCompleteMediaCommandService.generateStoryImage(event.getStoryId(), event.getPageId(), event.getBasePrompt(), event.getSeed());
+        conversationCompleteMediaCommandService.generateStoryPageImage(event.getStoryId(), event.getPageId(), event.getBasePrompt(), event.getSeed());
     }
 
     // 생성 완료된 페이지 이미지 개수 확인 및 스토리 상태 업데이트 (동기)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePageImageCompleted(CompletePageImageEvent event) {
-        conversationCompleteMediaCommandService.aggregateStoryPage(event.getStoryId());
+        conversationCompleteMediaCommandService.aggregateStoryPageImage(event.getStoryId());
     }
 }

--- a/src/main/java/com/example/demo/domain/conversation/event/StartConversationEventHandler.java
+++ b/src/main/java/com/example/demo/domain/conversation/event/StartConversationEventHandler.java
@@ -3,7 +3,6 @@ package com.example.demo.domain.conversation.event;
 import com.example.demo.domain.conversation.service.command.next.ConversationNextStoryCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteCommandService.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteCommandService.java
@@ -13,7 +13,7 @@ public interface ConversationCompleteCommandService {
     /**
      * 스토리 생성 진행 실패 -> 스토리 상태 업데이트
      */
-    void failStory(Long storyId, Story.StoryStatus failedStatus);
+    void updateFailedStory(Long storyId, Story.StoryStatus failedStatus);
 
     /**
      * 배치 대상 스토리의 retry_count를 +1하고 스토리 생성 이벤트 발행

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteCommandServiceImpl.java
@@ -37,18 +37,19 @@ public class ConversationCompleteCommandServiceImpl implements ConversationCompl
         ConversationSession session = sessionRepo.findById(sessionId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.SESSION_NOT_FOUND));
 
-        // 2. 현재 대화 단계가 END 인지 확인
-        if (session.getCurrentStep() != ConversationSession.ConversationStep.END) {
+        // 2. 현재 대화 세션 단계가 END 이고 상태가 COMPLETED 인지 확인
+        if (session.getCurrentStep() != ConversationSession.ConversationStep.END ||
+            session.getState() != ConversationSession.SessionState.COMPLETED
+        ) {
             throw new CustomException(ErrorStatus.SESSION_INVALID_STATE);
         }
-
 
         // 3. 스토리 상태 변경 MAKING 에서는 이어하기 불가
         if (story.getStoryStatus() == Story.StoryStatus.IN_PROGRESS) {
             story.setStoryStatus(Story.StoryStatus.MAKING);
         }
 
-        // 5. 커밋 이후 이벤트 발행: 비동기 작업 (동화 생성) 시작
+        // 4. 커밋 이후 이벤트 발행: 비동기 작업 (동화 생성) 시작
         TransactionSynchronizationManager.registerSynchronization(
                 new TransactionSynchronizationAdapter() {
                     @Override

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteCommandServiceImpl.java
@@ -63,7 +63,7 @@ public class ConversationCompleteCommandServiceImpl implements ConversationCompl
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void failStory(Long storyId, Story.StoryStatus failedStatus) {
+    public void updateFailedStory(Long storyId, Story.StoryStatus failedStatus) {
 
         // 1. 실패 상테 해당하는 enum 값 검증
         if (!failedStatus.isFailedStatus()) {

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteMediaCommandService.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteMediaCommandService.java
@@ -9,12 +9,12 @@ public interface ConversationCompleteMediaCommandService {
     void generateStoryMedia(Long storyId, String imageType);
 
     /**
-     * 개별 페이지 이미지 생성 및 페이지 상태 업데이트
+     * 이벤트 처리 로직 - 개별 페이지 이미지 생성 및 페이지 상태 업데이트
      */
-    void generateStoryImage(Long storyId, Long pageId, String basePrompt, Long Seed);
+    void generateStoryPageImage(Long storyId, Long pageId, String basePrompt, Long Seed);
 
     /**
-     * 생성 완료된 페이지 이미지 개수 확인 및 스토리 상태 업데이트
+     * 이벤트 처리 로직 - 생성 완료된 페이지 이미지 개수 확인 및 스토리 상태 업데이트
      */
-    void aggregateStoryPage(Long storyId);
+    void aggregateStoryPageImage(Long storyId);
 }

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteMediaCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteMediaCommandServiceImpl.java
@@ -17,6 +17,9 @@ import com.example.demo.domain.story.repository.StoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +45,7 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
     private final ApplicationEventPublisher eventPublisher;
 
     private final S3Uploader s3Uploader;
+    private final ConversationCompleteCommandService conversationCompleteCommandService;
     private final AvatarGeneratorService avatarGeneratorService;
     private final RunwayService runwayService;
 
@@ -205,8 +209,15 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
      * 페이지 이미지 생성
      * - 스토리 각 페이지별 이미지 생성 및 상태 업데이트
      * - 페이지별 prompt 조합 후 이미지 생성 및 S3 업로드
+     * - 최대 3번 생성 실패 시 > 최종 스토리 상태 IMAGE_FAILED 업데이트
      */
     @Override
+    @Retryable(
+            retryFor = Exception.class,      // 재시도를 수행할 예외 유형
+            recover = "recoverGenerateStoryPageImage", // 모든 재시도 실패 시 호출 메소드
+            maxAttempts = 3,                 // 최대 시도 횟수
+            backoff = @Backoff(delay = 1000) // 1초 대기
+    )
     @Transactional
     public void generateStoryPageImage(Long storyId, Long pageId, String basePrompt, Long seed) {
 
@@ -254,8 +265,17 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
             );
         } catch (Exception e) {
             log.error("===== [Page] {}번째 페이지 ERROR OCCURRED: pageId = {} =====", page.getPageNumber(), page.getId(), e);
-            throw e;  // CustomException 던지지 말고 원본 예외 그대로
+            throw e;
         }
+    }
+
+    // 페이지 이미지 모든 재시도 실패 시
+    @Recover
+    public void recoverGenerateStoryPageImage(Exception e, Long storyId, Long pageId, String basePrompt, Long seed) {
+        log.error("===== [Page] 페이지 이미지 생성 최종 실패: pageId={}, storyId={} =====", pageId, storyId, e);
+        // 페이지는 TEXT 상태 그대로
+        // 스토리 상태만 IMAGE_FAILED로 변경
+        conversationCompleteCommandService.updateFailedStory(storyId, Story.StoryStatus.IMAGE_FAILED);
     }
 
     /**

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteMediaCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteMediaCommandServiceImpl.java
@@ -63,10 +63,9 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
             // -- 이미지 생성
             // 2-1. 캐릭터 이미지 생성 및 상태 업테이트
             generateCharacterBaseImage(character);
-            character.setStatus(StoryCharacter.CharacterStatus.COMPLETED); // 이미지 생성 완료
 
             // 2-2. 스토리 페이지 이미지 생성
-            generateStoryImages(story, character); // 페이지별 생성 이벤트 발행
+            generateStoryPageImages(story, character); // 페이지별 생성 이벤트 발행
         } else {
             // -- 동영상 생성
             // 스토리 페이지별 동영상 생성
@@ -153,10 +152,10 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
 
                 character.getAppearance().setCharacterSeed(result.getSeed());
                 character.setImageUrl(s3Url);
+                character.setStatus(StoryCharacter.CharacterStatus.COMPLETED); // 이미지 생성 완료
             });
 
             log.info("===== [Avatar] END SUCCESS generateCharacterBaseImage =====");
-
         } catch (Exception e) {
             log.error("===== [Avatar] ERROR OCCURRED =====");
             log.error("Exception type: {}", e.getClass().getName());
@@ -170,9 +169,9 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
     /**
      * 스토리 페이지 이미지 생성
      * - 캐릭터 basePrompt, seed 사용 → 일관된 스타일 유지
-     * - 페이지별 생성 이벤트 발행함으로써 이미지 생성
+     * - 페이지별 생성 비동기 이벤트 발행함으로써 이미지 생성
      */
-    private void generateStoryImages(Story story, StoryCharacter character) {
+    private void generateStoryPageImages(Story story, StoryCharacter character) {
 
         // 1. 고정 값 조회
         String basePrompt = character.getAppearance().getCharacterPromptEn(); // 포즈 없이 외형만 정리된 프롬프트
@@ -185,7 +184,7 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
                 .map(StoryPage::getId)
                 .toList();
 
-        // 3. 페이지별 이미지 생성 이벤트 발행 → 리스너 generatePageImage 처리
+        // 3. 페이지별 이미지 생성 비동기 이벤트 발행 → 리스너 generatePageImage 처리
         TransactionSynchronizationManager.registerSynchronization(
                 new TransactionSynchronizationAdapter() {
                     @Override
@@ -201,13 +200,15 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
     }
 
     /**
-     * 이미지 생성 이벤트 처리 로직
+     * 이벤트 처리 로직
+     *
+     * 페이지 이미지 생성
      * - 스토리 각 페이지별 이미지 생성 및 상태 업데이트
      * - 페이지별 prompt 조합 후 이미지 생성 및 S3 업로드
      */
     @Override
     @Transactional
-    public void generateStoryImage(Long storyId, Long pageId, String basePrompt, Long seed) {
+    public void generateStoryPageImage(Long storyId, Long pageId, String basePrompt, Long seed) {
 
         // 1. Page 조회
         StoryPage page = storyPageRepo.findById(pageId)
@@ -242,7 +243,7 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
             page.setPageStatus(StoryPage.PageStatus.IMAGE); // 페이지 상태 업데이트 - 이미지 생성 완료
             log.info("===== [Page] {}번째 페이지 이미지 생성 완료: pageId = {}, storyId = {} =====", page.getPageNumber(), page.getId(), storyId);
 
-            // 7. 이미지 생성 완료 이벤트 발행 → 리스너 aggregateStoryPage 처리
+            // 7. 이미지 생성 완료 동기 이벤트 발행 → 리스너 aggregateStoryPage 처리
             TransactionSynchronizationManager.registerSynchronization(
                     new TransactionSynchronizationAdapter() {
                         @Override
@@ -258,19 +259,22 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
     }
 
     /**
-     * 이미지 생성 완료 이벤트 처리 로직
+     * 이벤트 처리 로직
+     *
+     * 페이지 이미지 생성 완료 동기
      * - 이미지 생성 완료된 페이지 개수 확인
      * - 이후 스토리 상태 업데이트
      */
     @Override
-    @Transactional
-    public void aggregateStoryPage(Long storyId) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void aggregateStoryPageImage(Long storyId) {
 
         // 1. 이미지 생성 완료된 페이지 개수 조회
         int imageCount = storyPageRepo.countByStoryIdAndPageStatus(storyId, StoryPage.PageStatus.IMAGE);
+        log.info("[Aggregate] storyId={}, imageCount={}", storyId, imageCount);
 
         // 2. 모든 페이지가 모두 생성 완료된 경우 스토리 상태 업데이트 (페이지 개수 = 4)
-        if(imageCount == 4) {
+        if (imageCount == 4) {
             Story story = storyRepo.findById(storyId)
                     .orElseThrow(() -> new CustomException(ErrorStatus.STORY_NOT_FOUND));
 
@@ -279,7 +283,7 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
                 // 3. 스토리 상태 업데이트 - 모든 이미지 생성 완료
                 story.setStoryStatus(Story.StoryStatus.IMAGE_COMPLETED);
 
-                // 4. 스토리 생성 완료 이벤트 발행
+                // 4. 동화 완성 이벤트 발행
                 Long userId = story.getUser().getId();
                 TransactionSynchronizationManager.registerSynchronization(
                         new TransactionSynchronizationAdapter() {

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteMediaCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteMediaCommandServiceImpl.java
@@ -181,7 +181,7 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
 
         // 2. 페이지 id만 추출
         List<Long> pageIds = story.getStoryPages().stream()
-                .filter(page -> page.getStatus() == StoryPage.PageStatus.TEXT)
+                .filter(page -> page.getPageStatus() == StoryPage.PageStatus.TEXT)
                 .map(StoryPage::getId)
                 .toList();
 
@@ -214,7 +214,7 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
                 .orElseThrow(() -> new CustomException(ErrorStatus.STORY_PAGE_NOT_FOUND));
 
         // 2. Page 상태가 TEXT인지 확인
-        if (page.getStatus() != StoryPage.PageStatus.TEXT) {
+        if (page.getPageStatus() != StoryPage.PageStatus.TEXT) {
             log.info("===== [Page] {}번째 페이지 이미지 이미 생성됨: pageId = {}, storyId = {} =====", page.getPageNumber(), page.getId(), storyId);
             return;
         }
@@ -239,7 +239,7 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
             }
 
             // 6. DB 저장 (Page.status = IMAGE)
-            page.setStatus(StoryPage.PageStatus.IMAGE); // 페이지 상태 업데이트 - 이미지 생성 완료
+            page.setPageStatus(StoryPage.PageStatus.IMAGE); // 페이지 상태 업데이트 - 이미지 생성 완료
             log.info("===== [Page] {}번째 페이지 이미지 생성 완료: pageId = {}, storyId = {} =====", page.getPageNumber(), page.getId(), storyId);
 
             // 7. 이미지 생성 완료 이벤트 발행 → 리스너 aggregateStoryPage 처리
@@ -267,7 +267,7 @@ public class ConversationCompleteMediaCommandServiceImpl implements Conversation
     public void aggregateStoryPage(Long storyId) {
 
         // 1. 이미지 생성 완료된 페이지 개수 조회
-        int imageCount = storyPageRepo.countByStoryIdAndStatus(storyId, StoryPage.PageStatus.IMAGE);
+        int imageCount = storyPageRepo.countByStoryIdAndPageStatus(storyId, StoryPage.PageStatus.IMAGE);
 
         // 2. 모든 페이지가 모두 생성 완료된 경우 스토리 상태 업데이트 (페이지 개수 = 4)
         if(imageCount == 4) {

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteOrchestrator.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteOrchestrator.java
@@ -49,7 +49,7 @@ public class ConversationCompleteOrchestrator {
             } catch (Exception e) {
                 // 스토리 정제 실패 처리
                 log.error("[orchestrateCompletion] 스토리 정제 실패 storyId={}", storyId, e);
-                conversationCompleteCommandService.failStory(storyId, Story.StoryStatus.TEXT_FAILED);
+                conversationCompleteCommandService.updateFailedStory(storyId, Story.StoryStatus.TEXT_FAILED);
                 return;
             }
 
@@ -64,7 +64,7 @@ public class ConversationCompleteOrchestrator {
             } catch (Exception e) {
                 // 이미지 생성 실패 처리
                 log.error("[orchestrateCompletion] 이미지 생성 실패 storyId={}", storyId, e);
-                conversationCompleteCommandService.failStory(storyId, Story.StoryStatus.IMAGE_FAILED);
+                conversationCompleteCommandService.updateFailedStory(storyId, Story.StoryStatus.IMAGE_FAILED);
                 return;
             }
         }

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteTextCommandService.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteTextCommandService.java
@@ -1,7 +1,5 @@
 package com.example.demo.domain.conversation.service.command.complete;
 
-import com.example.demo.domain.story.entity.Story;
-
 public interface ConversationCompleteTextCommandService {
 
     /**

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteTextCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteTextCommandServiceImpl.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteTextCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteTextCommandServiceImpl.java
@@ -101,7 +101,7 @@ public class ConversationCompleteTextCommandServiceImpl implements ConversationC
                     .pageNumber(i + 1)
                     .content(pages[i])
                     .contentEn(pagesEn[i])
-                    .status(StoryPage.PageStatus.TEXT)
+                    .pageStatus(StoryPage.PageStatus.TEXT)
                     .videoStatus(StoryPage.VideoStatus.NONE)
                     .story(story)
                     .build();

--- a/src/main/java/com/example/demo/domain/conversation/service/command/next/ConversationNextStoryCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/next/ConversationNextStoryCommandServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -25,7 +26,7 @@ public class ConversationNextStoryCommandServiceImpl implements ConversationNext
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void startNextStep(Long sessionId) {
 
         // 1. 세션 조회

--- a/src/main/java/com/example/demo/domain/story/entity/StoryPage.java
+++ b/src/main/java/com/example/demo/domain/story/entity/StoryPage.java
@@ -32,7 +32,7 @@ public class StoryPage {
     // 페이지 생성 상태
     @Enumerated(EnumType.STRING)
     @Column(name = "page_status", nullable = false)
-    private PageStatus status = PageStatus.TEXT;
+    private PageStatus pageStatus = PageStatus.TEXT;
 
     public enum PageStatus {
         TEXT,

--- a/src/main/java/com/example/demo/domain/story/repository/StoryPageRepository.java
+++ b/src/main/java/com/example/demo/domain/story/repository/StoryPageRepository.java
@@ -11,5 +11,5 @@ public interface StoryPageRepository extends JpaRepository<StoryPage, Long> {
     Optional<StoryPage> findByStory_IdAndPageNumber(Long storyId, int pageNumber);
 
     // 페이지 이미지 생성 완료 개수 조회
-    int countByStoryIdAndStatus(Long storyId, StoryPage.PageStatus status);
+    int countByStoryIdAndPageStatus(Long storyId, StoryPage.PageStatus pageStatus);
 }

--- a/src/main/java/com/example/demo/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/example/demo/domain/story/repository/StoryRepository.java
@@ -32,4 +32,13 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
     """)
     List<Story> findIncompleteStoriesForAdmin();
 
+    // 관리자용 - 스토리 재생성 배치 실패 동화 조회 (배치 횟수 3회 이상이고, 완성 상태가 아닌 동화)
+    @Query("""
+        SELECT s FROM Story s
+        WHERE s.retryCount >= 3
+            AND s.storyStatus NOT IN :complete
+    """)
+    List<Story> findFailedRetryStoriesForAdmin(
+            @Param("complete") List<Story.StoryStatus> completeStatus
+    );
 }

--- a/src/main/java/com/example/demo/domain/story/scheduler/StoryRetryScheduler.java
+++ b/src/main/java/com/example/demo/domain/story/scheduler/StoryRetryScheduler.java
@@ -25,7 +25,7 @@ public class StoryRetryScheduler {
      * 매일 자정 스토리 재생성 배치 시작
      * - 실패 및 미완료 스토리 대상으로 스토리 생성 이벤트(CompleteConversationEvent) 발행
      */
-    @Scheduled(cron = "10 56 2 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void retryScheduledStories() {
         log.info("[BATCH] 실패 및 오래된 스토리 재생성 배치 시작");
 

--- a/src/main/java/com/example/demo/domain/story/service/query/StoryAdminQueryService.java
+++ b/src/main/java/com/example/demo/domain/story/service/query/StoryAdminQueryService.java
@@ -1,6 +1,8 @@
 package com.example.demo.domain.story.service.query;
 
 import com.example.demo.domain.story.web.dto.StoryAdminResponseDto;
+import com.example.demo.domain.story.web.dto.StoryFailedAdminResponseDto;
+
 import java.util.List;
 
 public interface StoryAdminQueryService {
@@ -8,4 +10,6 @@ public interface StoryAdminQueryService {
     // 미완성 동화 조회
     List<StoryAdminResponseDto> getIncompleteStories();
 
+    // 스토리 재생성 배치 실패 동화 조회
+    List<StoryFailedAdminResponseDto> getFailedRetryStories();
 }

--- a/src/main/java/com/example/demo/domain/story/service/query/StoryAdminQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/story/service/query/StoryAdminQueryServiceImpl.java
@@ -1,10 +1,13 @@
 package com.example.demo.domain.story.service.query;
 
+import com.example.demo.domain.story.entity.Story;
 import com.example.demo.domain.story.repository.StoryRepository;
 import com.example.demo.domain.story.web.dto.StoryAdminResponseDto;
+import com.example.demo.domain.story.web.dto.StoryFailedAdminResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -21,4 +24,17 @@ public class StoryAdminQueryServiceImpl implements StoryAdminQueryService {
                 .toList();
     }
 
+    // 스토리 재생성 배치 실패 동화 조회
+    @Override
+    public List<StoryFailedAdminResponseDto> getFailedRetryStories() {
+        return storyRepository.findFailedRetryStoriesForAdmin(
+                    Arrays.asList(
+                        Story.StoryStatus.IMAGE_COMPLETED,
+                        Story.StoryStatus.VIDEO_COMPLETED
+                    )
+                )
+                .stream()
+                .map(StoryFailedAdminResponseDto::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/example/demo/domain/story/web/controller/StoryAdminController.java
+++ b/src/main/java/com/example/demo/domain/story/web/controller/StoryAdminController.java
@@ -5,6 +5,7 @@ import com.example.demo.apiPayload.status.SuccessStatus;
 import com.example.demo.domain.story.service.command.StoryAdminCommandService;
 import com.example.demo.domain.story.service.query.StoryAdminQueryService;
 import com.example.demo.domain.story.web.dto.StoryAdminResponseDto;
+import com.example.demo.domain.story.web.dto.StoryFailedAdminResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +26,12 @@ public class StoryAdminController {
         return ApiResponse.of(SuccessStatus._OK, storyAdminQueryService.getIncompleteStories());
     }
 
+    @Operation(summary = "스토리 재생성 배치에 실패한 동화 조회")
+    @GetMapping("/failed-retry")
+    public ApiResponse<List<StoryFailedAdminResponseDto>> getFailedRetryStories() {
+        return ApiResponse.of(SuccessStatus._OK, storyAdminQueryService.getFailedRetryStories());
+    }
+
     @Operation(summary = "이미지용 유튜브 링크 업로드")
     @PostMapping("/{id}/youtube/image")
     public ApiResponse<String> uploadImageYoutube(
@@ -42,5 +49,4 @@ public class StoryAdminController {
     ) {
         return ApiResponse.of(SuccessStatus._OK, storyAdminCommandService.uploadVideoYoutube(id, youtubeLink));
     }
-
 }

--- a/src/main/java/com/example/demo/domain/story/web/dto/StoryFailedAdminResponseDto.java
+++ b/src/main/java/com/example/demo/domain/story/web/dto/StoryFailedAdminResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.demo.domain.story.web.dto;
+
+import com.example.demo.domain.story.entity.Story;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StoryFailedAdminResponseDto {
+
+    private Long storyId;
+    private int retryCount;
+    private String storyStatus;
+    private LocalDateTime updatedAt;
+
+    public static StoryFailedAdminResponseDto from(Story story) {
+
+        return StoryFailedAdminResponseDto.builder()
+                .storyId(story.getId())
+                .retryCount(story.getRetryCount())
+                .storyStatus(story.getStoryStatus().name())
+                .updatedAt(story.getUpdatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->
1. 스토리 재생성 배치 3회 이상 실패 동화 조회 가능한 관리자용 api(`GET /api/admin/stories/failed-retry`) 추가 (+ 배치 시간 자정으로 수정) 
    - 실패 (관리자가 아닐 때)
        <img width="1406" height="710" alt="스크린샷 2026-04-29 오후 4 08 34" src="https://github.com/user-attachments/assets/165e5458-314b-460f-ac53-2c9d1ca5b724" />

    - 성공 (스토리 아이디 / retry 횟수 / 스토리 상태 / 스토리 업데이트 조회 가능)
       <img width="1396" height="463" alt="스크린샷 2026-04-29 오후 4 10 00" src="https://github.com/user-attachments/assets/094755f0-4689-4784-8328-624fbb8b8dc3" />
2. afterCommit 후속 DB 작업에 REQUIRES_NEW 트랜잭션 적용
   1. 스토리 생성 작업 시작 시에 DB 저장이 안되어 조회 불가능 에러가 뜨는 걸 발견했습니다.
       <img width="329" height="153" alt="스크린샷 2026-04-30 오후 12 05 33" src="https://github.com/user-attachments/assets/a4fa554b-2577-4ab0-ae80-5e83e6fbb949" />
       - `TransactionSynchronizationManager.registerSynchronization`로 등록한 후속 db 작업시 `@Transactional(REQUIRED)`는 이미 커밋된 트랜잭션에 DB 저장하려 하므로 저장할 값이 반영되지 않음
       (= 트랜잭션 컨텍스트는 스레드 로컬에 남아있으나, 이미 커밋 완료된 물리 트랜잭션이라 DB 작업 불가)
        - `@Transactional(REQUIRES_NEW)`로 새 트랜잭션 열어 확실하게 db 저장 작업을 완료하도록 함
   
   2. 위 문제와 동일한 이유로 스토리 완성 시, 스토리 상태가 `IMAGE_COMPLETE`로 반영되지 않은 문제 발견했습니다.
       <img width="1229" height="152" alt="스크린샷 2026-04-29 오후 4 09 39" src="https://github.com/user-attachments/assets/6b733941-101d-4598-a455-65f23e4f8e97" />
       - 동일하게 `aggregateStoryPageImage()`에 `@Transactional(REQUIRES_NEW) `추가
          1. 스토리 `/complete` 요청 시 (`IN_PROGRESS` > `MAKING` 상태 변경)
             <img width="1374" height="46" alt="스크린샷 2026-04-30 오후 12 49 28" src="https://github.com/user-attachments/assets/29b25629-2bdd-4df2-b773-fd7f6fe05a15" />
             <img width="1379" height="38" alt="스크린샷 2026-04-30 오후 12 50 07" src="https://github.com/user-attachments/assets/1f1354d8-6dd1-407c-93e1-81ee54b7dbb7" />

          2. 페이지 병렬 생성 작업
              <img width="1333" height="94" alt="스크린샷 2026-04-30 오후 12 57 52" src="https://github.com/user-attachments/assets/3fbffd8e-269e-4c8a-95e7-5798c75e9345" />
          3. 이미지 작업 모두 완료 (스토리 상테 `IMAGE_COMPLETE` 변경 완료, 캐릭터 상태, 페이지 상태 모두 변경 완료) 
              <img width="1405" height="45" alt="스크린샷 2026-04-30 오후 12 51 13" src="https://github.com/user-attachments/assets/521d2844-3b19-4649-8812-4dfb8bc59fff" />
              <img width="1187" height="19" alt="스크린샷 2026-04-30 오후 12 52 08" src="https://github.com/user-attachments/assets/51d18514-0d21-40ab-8074-ba7cee52b748" />
              <img width="1140" height="74" alt="스크린샷 2026-04-30 오후 12 51 57" src="https://github.com/user-attachments/assets/4e157fee-63bf-438f-8264-c5a18eb83fe5" />

       -  대시보드도 정상 동작 완료
          <img width="289" height="76" alt="스크린샷 2026-04-30 오후 12 52 54" src="https://github.com/user-attachments/assets/962902af-544b-4bfd-9a4a-34d662b4f846" />

   

    
4. 기타 작업
    - 메소드 및 페이지 이름 수정(page의 status -> pageStatus / failStory -> updateFailedStory() 등)
    - `build.gradle`에 런타임용 macOS 네이티브 DNS 리졸버 런타임 의존성 추가

## 🔗 관련 이슈
- Closes #61 #62

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
- @Transactional(REQUIRES_NEW) 추가한 대상: 
   - `ConversationNextStoryEventHandler`, 
   - `ConversationNextStoryCommandServiceImpl`, 
   - `ConversationCompleteMediaCommandService > aggregateStoryPageImage()`
- 노션 작업도 마무리 하겠습니다