### PR TITLE
♻️refactor: 스토리 완성된 캐릭터만 조회 기능으로 수정

### DIFF
--- a/src/main/java/com/example/demo/domain/character/repository/StoryCharacterRepository.java
+++ b/src/main/java/com/example/demo/domain/character/repository/StoryCharacterRepository.java
@@ -1,17 +1,41 @@
 package com.example.demo.domain.character.repository;
 
 import com.example.demo.domain.character.entity.StoryCharacter;
+import com.example.demo.domain.story.entity.Story;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.example.demo.domain.user.entity.User;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.List;
 
 public interface StoryCharacterRepository extends JpaRepository<StoryCharacter, Long> {
 
-    // 특정 유저의 모든 캐릭터 조회
-    List<StoryCharacter> findByStory_User(User user);
+    // 특정 유저의 완료된 스토리의 모든 캐릭터 조회
+    @Query("""
+        SELECT c 
+        FROM StoryCharacter c
+        JOIN FETCH c.story s
+            WHERE s.user = :user
+                AND s.storyStatus IN :success
+    """)
+    List<StoryCharacter> findByUserAndStoryStatus(
+            @Param("user") User user,
+            @Param("success") List<Story.StoryStatus> successStatus
+    );
 
-    // 완료된 캐릭터만 조회
-    Optional<StoryCharacter> findByIdAndStatus(Long id, StoryCharacter.CharacterStatus status);
+    // 완료된 특정 캐릭터 상세 조회
+    @Query("""
+        SELECT c
+        FROM StoryCharacter c
+            JOIN FETCH c.story s
+            LEFT JOIN FETCH s.storyPages
+                WHERE c.id = :id
+                     AND s.storyStatus IN :success
+    """)
+    Optional<StoryCharacter> findByIdAndStoryStatus(
+            @Param("id") Long characterId,
+            @Param("success") List<Story.StoryStatus> successStatus
+    );
 }

--- a/src/main/java/com/example/demo/domain/character/service/query/CharacterQueryServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/character/service/query/CharacterQueryServiceImpl.java
@@ -7,12 +7,14 @@ import com.example.demo.domain.character.entity.StoryCharacter;
 import com.example.demo.domain.character.repository.StoryCharacterRepository;
 import com.example.demo.domain.character.repository.UserCharacterFavoriteRepository;
 import com.example.demo.domain.character.web.dto.CompletedCharacterResponse;
+import com.example.demo.domain.story.entity.Story;
 import com.example.demo.domain.user.entity.User;
 import com.example.demo.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -32,8 +34,14 @@ public class CharacterQueryServiceImpl implements CharacterQueryService {
     @Override
     public CompletedCharacterResponse.CharacterListResponse getCompletedCharacters(User user, StoryCharacter.Gender gender) {
 
-        // 1. 유저의 모든 캐릭터 가져오기
-        List<StoryCharacter> characters = storyCharacterRepository.findByStory_User(user);
+        // 1. 유저의 모든 캐릭터 가져오기 (스토리 완료된 캐릭터만)
+        List<StoryCharacter> characters = storyCharacterRepository.findByUserAndStoryStatus(
+                user,
+                Arrays.asList(
+                        Story.StoryStatus.IMAGE_COMPLETED,
+                        Story.StoryStatus.VIDEO_COMPLETED
+                )
+        );
 
         // 2. 성별 필터링 (null 이면 전체)
         if (gender != null) {
@@ -47,13 +55,12 @@ public class CharacterQueryServiceImpl implements CharacterQueryService {
                 .map(fav -> fav.getCharacter().getId())
                 .collect(Collectors.toSet());
 
-        // 4. 정렬 (미완성 → 관심 → 최신순)
+        // 4. 정렬 (관심 → 최신순)
         List<StoryCharacter> sorted = characters.stream()
                 .sorted(Comparator
                         .comparingInt((StoryCharacter c) -> {
-                            if (c.getStatus() != StoryCharacter.CharacterStatus.COMPLETED) return 0;  // 미완성
-                            if (favoriteIds.contains(c.getId())) return 1;                              // 완성 & 관심
-                            return 2;                                                                  // 완성 & 비관심
+                            if (favoriteIds.contains(c.getId())) return 0;                              // 완성 & 관심
+                            return 1;                                                                  // 완성 & 비관심
                         })
                         .thenComparing(StoryCharacter::getCreatedAt, Comparator.reverseOrder())        // 최신순
                 )
@@ -70,9 +77,13 @@ public class CharacterQueryServiceImpl implements CharacterQueryService {
         User fullUser = userRepository.findByIdWithFavorites(user.getId())
                 .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
 
-        // 2. 캐릭터 조회 (완료된 캐릭터만)
-        StoryCharacter character = storyCharacterRepository.findByIdAndStatus(
-                characterId, StoryCharacter.CharacterStatus.COMPLETED
+        // 2. 캐릭터 조회 (스토리 완료된 캐릭터만)
+        StoryCharacter character = storyCharacterRepository.findByIdAndStoryStatus(
+                characterId,
+                Arrays.asList(
+                        Story.StoryStatus.IMAGE_COMPLETED,
+                        Story.StoryStatus.VIDEO_COMPLETED
+                )
         ).orElseThrow(() -> new CustomException(ErrorStatus.CHARACTER_NOT_FOUND));
 
         // 3. 관심 캐릭터 여부 확인

--- a/src/main/java/com/example/demo/domain/character/web/controller/CharacterController.java
+++ b/src/main/java/com/example/demo/domain/character/web/controller/CharacterController.java
@@ -24,8 +24,8 @@ public class CharacterController extends AuthController {
     @Operation(
             summary = "캐릭터 전체 조회",
             description = """
-            - 캐릭터 전체 반환
-            - 정렬 기준 : 미완성 -> 관심 캐릭터 -> createTime 내림차순
+            - 완료된 스토리의 캐릭터 전체 반환
+            - 정렬 기준 : 관심 캐릭터 -> createTime 내림차순
             - 옵션 : gender=FEMALE(여자만), gender=MALE(남자만), 기본은 전체
             """
     )
@@ -44,7 +44,7 @@ public class CharacterController extends AuthController {
             summary = "캐릭터 상세 조회",
             description = """
                 - 단일 캐릭터 상세 정보 조회
-                - 완료된 캐릭터만 조회 가능
+                - 완료된 스토리의 캐릭터만 조회 가능
                 - 관련된 동화 정보 포함
                 """
     )

--- a/src/main/java/com/example/demo/domain/conversation/repository/ConversationSessionRepository.java
+++ b/src/main/java/com/example/demo/domain/conversation/repository/ConversationSessionRepository.java
@@ -35,8 +35,7 @@ public interface ConversationSessionRepository extends JpaRepository<Conversatio
                     OR (s.storyStatus IN :stale AND s.updatedAt < :threshold)
                     )
                 AND s.retryCount < 3
-    """
-    )
+    """)
     List<ConversationSession> findRetryTargetSessions(
             @Param("step") ConversationSession.ConversationStep step,
             @Param("fail") List<Story.StoryStatus> failStatus,

--- a/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteOrchestrator.java
+++ b/src/main/java/com/example/demo/domain/conversation/service/command/complete/ConversationCompleteOrchestrator.java
@@ -53,7 +53,6 @@ public class ConversationCompleteOrchestrator {
                 conversationCompleteCommandService.updateFailedStory(storyId, Story.StoryStatus.TEXT_FAILED);
                 return;
             }
-
         }
 
         // 3. 이미지 생성: 캐릭터 및 페이지 이미지 생성


### PR DESCRIPTION
## 🚀 변경사항
- 스토리캐릭터 리포지토리에 스토리 상태 조건 추가
   - 완성된 스토리의 캐릭터만 볼 수 있도록 Story 테이블과 패치 조인 추가
   - 특정 캐릭터 상세 조회 시, Story와 StoryPage 테이블과 패치조인 추가
- 보관함 캐릭터 전체 조회 시, 조회 순서에  **미완성 조건** 제거 (관심 순, 최신 순 유지)

로컬 테이블
- 캐릭터 엔티티: 이미지 완성된 **캐릭터는 2,3,4,8,9** 지만 이중 페이지 생성 안 된(=스토리가 완성되지 않은) **캐릭터 3,4**가 존재함 
   <img width="1206" height="236" alt="스크린샷 2026-05-03 오후 11 37 35" src="https://github.com/user-attachments/assets/44646055-6776-4096-89bf-a2d4dc0b179c" />
- 스토리 엔티티: 페이지 이미지까지 완성된 **스토리 2, 8, 9** -> `IMAGE_COMPLETED`는 사용자 조회 가능
   <img width="1208" height="252" alt="image" src="https://github.com/user-attachments/assets/4c231698-d44c-4e6e-ad75-58230f88e2ac" />
즉, 사용자 보관함에서도 2, 8, 9만 조회 가능해야 함

스웨거 테스트
- 전체 캐릭터 조회(보관함)
   - <img width="855" height="407" alt="스크린샷 2026-05-03 오후 11 44 40" src="https://github.com/user-attachments/assets/a5dc2415-0ca3-475e-8cdb-84ca278f71bf" />
   - 2, 8, 9 조회 가능

- 특정 캐릭터 조회
   - <img width="733" height="734" alt="스크린샷 2026-05-03 오후 11 46 59" src="https://github.com/user-attachments/assets/4fef0f45-f409-4a4d-8f89-5ba54a134666" />
   - 캐릭터 2 조회 성공

   <img width="693" height="612" alt="image" src="https://github.com/user-attachments/assets/f4de106e-383e-486d-8c48-2080dc4868c6" />
   - 위 2,8,9 아닌(=보관함에서 조회 불가한) 캐릭터 조회 시 실패


## 🔗 관련 이슈
- Closes #66 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료