### PR TITLE
♻️refactor: 회원가입 시, 일반/선생님 역할 분기 추가

### DIFF
--- a/src/main/java/com/example/demo/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/example/demo/apiPayload/status/ErrorStatus.java
@@ -35,9 +35,10 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "USER_4001", "이미 로그아웃된 사용자입니다."),
     USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_4002", "이미 삭제된 사용자입니다."),
     USER_INVALID_POINT(HttpStatus.BAD_REQUEST, "USER_4003", "사용자의 포인트가 부족합니다."),
+    USER_ROLE_CHANGE_FAILED(HttpStatus.FORBIDDEN, "USER_4005", "일반 유저는 관리자 역할로 바꿀 수 없습니다."),
 
     // 관리자 관련 에러
-    ADMIN_UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "ADMIN_4003", "관리자 권한이 필요한 접근입니다. 관리자 계정으로 로그인하세요."),
+    ADMIN_UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "ADMIN_4001", "관리자 권한이 필요한 접근입니다. 관리자 계정으로 로그인하세요."),
 
     // 대화 관련 에러
     CHAT_GPT_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT_GPT_5001", "ChatGPT API 호출에 실패했습니다. 관리자에게 문의하세요."),

--- a/src/main/java/com/example/demo/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/example/demo/apiPayload/status/ErrorStatus.java
@@ -30,6 +30,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "EMAIL_4001", "이메일을 찾을 수 없습니다. 올바른 이메일을 입력하세요."),
 
+    EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "EMAIL_VERIFICATION_4001", "인증코드가 만료되었습니다. 인증을 다시 요청하세요."),
+    EMAIL_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "EMAIL_VERIFICATION_4002", "인증코드가 일치하지 않습니다."),
+    EMAIL_VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "EMAIL_VERIFICATION_4003", "이메일 인증 요청 내역을 찾을 수 없습니다."),
+    EMAIL_VERIFICATION_NOT_COMPLETED(HttpStatus.FORBIDDEN, "EMAIL_VERIFICATION_4004", "이메일 인증이 완료되지 않았거나 만료되었습니다. 인증을 다시 진행하세요."),
+    EMAIL_VERIFICATION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "EMAIL_VERIFICATION_4005", "이미 다른 계정에서 인증된 이메일입니다."),
+
     // 회원 관련 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4004", "사용자를 찾을 수 없습니다."),
     USER_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "USER_4001", "이미 로그아웃된 사용자입니다."),

--- a/src/main/java/com/example/demo/domain/user/entity/EmailVerification.java
+++ b/src/main/java/com/example/demo/domain/user/entity/EmailVerification.java
@@ -1,0 +1,65 @@
+package com.example.demo.domain.user.entity;
+
+import com.example.demo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "email_verification_entity")
+public class EmailVerification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 사용자 이메일
+    private String email;
+
+    // 이메일 인증 코드
+    private String code;
+
+    // 이메일 인증 시각 (null이면 미인증)
+    private LocalDateTime verifiedAt;
+
+    // 이메일을 소유한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 생성자
+    @Builder
+    private EmailVerification(String email, String code, User user) {
+        this.email = email;
+        this.code = code;
+        this.user = user;
+    }
+
+    // 인증코드 만료 여부 > TTL(5분)
+    public boolean isExpired() {
+        return getCreatedAt().isBefore(BaseEntity.now().minusMinutes(5));
+    }
+
+    // 인증코드 일치 확인
+    public boolean isEqual(String emailCode) {
+        return this.code.equals(emailCode);
+    }
+
+    // 이메일 인증 시각 기록
+    public void verify() {
+        this.verifiedAt = BaseEntity.now();
+    }
+
+    // 이메일 인증 여부
+    public boolean isVerified() {
+        return this.verifiedAt != null;
+    }
+
+    // 이메일 인증 유효 여부 > TTL(30분)
+    public boolean isValid() {
+        return isVerified() && this.verifiedAt.isAfter(BaseEntity.now().minusMinutes(30));
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/entity/User.java
+++ b/src/main/java/com/example/demo/domain/user/entity/User.java
@@ -72,6 +72,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<UserCharacterFavorite> favorites = new HashSet<>();
 
+    // 사용자 삭제 시 이메일 인증 내역도 삭제
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<EmailVerification> emailVerifications = new HashSet<>();
+
     // 약관 1 : 스토리와 캐릭터는 운영자만 삭제 가능합니다. 삭제를 원할 시 별도 신청/문의가 필요합니다.
     //         추후 공유 기능 개발 예정이고 다른 사용자들이 캐릭터와 유대감을 쌓을 수 있으므로 중대한 이유가 아닌 이상 삭제 불가합니다.
     // 약관 2 : 사용자 대화 기록과 즐겨찾기는 탈퇴시 자동으로 삭제됩니다.
@@ -90,10 +94,7 @@ public class User extends BaseEntity {
 
     // 사용자 역할 전환 (관리자 전환 불가)
     public void changeRole(UserGrade newGrade) {
-        if (newGrade == UserGrade.ADMIN) {
-            throw new CustomException(ErrorStatus.USER_ROLE_CHANGE_FAILED);
-        }
-
+        if (newGrade == UserGrade.ADMIN) throw new CustomException(ErrorStatus.USER_ROLE_CHANGE_FAILED);
         this.grade = newGrade;
     }
 

--- a/src/main/java/com/example/demo/domain/user/entity/User.java
+++ b/src/main/java/com/example/demo/domain/user/entity/User.java
@@ -77,7 +77,8 @@ public class User extends BaseEntity {
     // 약관 2 : 사용자 대화 기록과 즐겨찾기는 탈퇴시 자동으로 삭제됩니다.
 
     public enum UserGrade {
-        BASIC,    // 기본 사용자
+        BASIC,    // 기본 사용자 (= 학생)
+        TEACHER,  // 선생님
         ADMIN     // 관리자
     }
 
@@ -87,10 +88,18 @@ public class User extends BaseEntity {
         DELETED   // 회원 탈퇴
     }
 
+    // 사용자 역할 전환 (관리자 전환 불가)
+    public void changeRole(UserGrade newGrade) {
+        if (newGrade == UserGrade.ADMIN) {
+            throw new CustomException(ErrorStatus.USER_ROLE_CHANGE_FAILED);
+        }
+
+        this.grade = newGrade;
+    }
+
     // 사용자 상태를 활성화로 변경
     public void activate() {
         this.status = UserStatus.ACTIVE;
-        this.setAgreedToTerms(true); // 활성화 시 약관 동의로 설정
         this.deletedAt = null; // 활성화 시 삭제 일시 초기화
     }
 

--- a/src/main/java/com/example/demo/domain/user/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/example/demo/domain/user/repository/EmailVerificationRepository.java
@@ -1,0 +1,15 @@
+package com.example.demo.domain.user.repository;
+
+import com.example.demo.domain.user.entity.EmailVerification;
+import com.example.demo.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findByEmail(String email);
+    Optional<EmailVerification> findByUser(User user);
+    void deleteAllByUser(User user);
+}

--- a/src/main/java/com/example/demo/domain/user/service/command/EmailVerificationCommandService.java
+++ b/src/main/java/com/example/demo/domain/user/service/command/EmailVerificationCommandService.java
@@ -1,0 +1,14 @@
+package com.example.demo.domain.user.service.command;
+
+/**
+ * 이메일 인증 관련 Command 서비스
+ * 이메일 인증코드 발송 및 검증
+ */
+public interface EmailVerificationCommandService {
+
+    // 이메일 인증코드 발송
+    public void sendCode(String tempCode, String email);
+
+    // 이메일 인증코드 검증
+    public void verifyCode(String tempCode, String code);
+}

--- a/src/main/java/com/example/demo/domain/user/service/command/EmailVerificationCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/user/service/command/EmailVerificationCommandServiceImpl.java
@@ -1,0 +1,85 @@
+package com.example.demo.domain.user.service.command;
+
+import com.example.demo.apiPayload.code.exception.CustomException;
+import com.example.demo.apiPayload.status.ErrorStatus;
+import com.example.demo.domain.user.entity.EmailVerification;
+import com.example.demo.domain.user.entity.Token;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.repository.EmailVerificationRepository;
+import com.example.demo.domain.user.repository.TokenRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 이메일 인증 관련 Command 서비스
+ * 이메일 인증코드 발송 및 검증
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EmailVerificationCommandServiceImpl implements EmailVerificationCommandService {
+
+    private final TokenRepository tokenRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
+    //private final MailSender mailSender;
+
+    // 이메일 인증코드 발송
+    @Override
+    public void sendCode(String tempCode, String email) {
+
+        // 이미 다른 계정에서 인증된 이메일인 경우
+        emailVerificationRepository.findByEmail(email)
+                .filter(EmailVerification::isVerified)
+                .ifPresent(ev -> {
+                    throw new CustomException(ErrorStatus.EMAIL_VERIFICATION_ALREADY_COMPLETED);
+                });
+
+
+        // 본인 기존 인증 시도 삭제 (재요청/이메일 변경 시 이전 것 무효화)
+        User user = getUserByTempCode(tempCode);
+        emailVerificationRepository.deleteAllByUser(user);
+
+        // 6자리 랜덤 숫자
+        String code = String.valueOf((int) (Math.random() * 900000) + 100000);
+
+        EmailVerification emailVerification = EmailVerification.builder()
+                .email(email)
+                .code(code)
+                .user(user)
+                .build();
+        emailVerificationRepository.save(emailVerification);
+
+        //mailSender.send(email, "[Storictor] 이메일 인증코드", "인증코드: " + code);
+    }
+
+    // 이메일 인증코드 검증
+    @Override
+    public void verifyCode(String tempCode, String code) {
+
+        // 인증 내역 조회
+        User user = getUserByTempCode(tempCode);
+        EmailVerification emailVerification = emailVerificationRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(ErrorStatus.EMAIL_VERIFICATION_NOT_FOUND));
+
+        // 인증코드 유효시간 확인
+        if (emailVerification.isExpired()) {
+            throw new CustomException(ErrorStatus.EMAIL_VERIFICATION_CODE_EXPIRED);
+        }
+
+        // 인증코드 일치 확인
+        if (!emailVerification.isEqual(code)) {
+            throw new CustomException(ErrorStatus.EMAIL_VERIFICATION_CODE_MISMATCH);
+        }
+
+        emailVerification.verify();
+    }
+
+    // 임시 토큰으로 사용자 조회
+    private User getUserByTempCode(String tempCode) {
+        Token token = tokenRepository.findByTempCode(tempCode)
+                .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
+
+        return token.getUser();
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/example/demo/domain/user/service/command/UserCommandService.java
@@ -24,9 +24,10 @@ public interface UserCommandService {
      * tempCode로 토큰 조회 후 사용자 활성화 및 토큰 반환
      *
      * @param tempCode 임시 코드
+     * @param role 사용자 역할(학생/선생님)
      * @return 로그인 결과가 담긴 LoginResult
      */
-    LoginResponseDto.LoginResult loginUser(String tempCode);
+    LoginResponseDto.LoginResult loginUser(String tempCode, User.UserGrade role);
 
     /**
      * 사용자 비활성화 (로그아웃)

--- a/src/main/java/com/example/demo/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/user/service/command/UserCommandServiceImpl.java
@@ -6,8 +6,10 @@ import com.example.demo.domain.character.repository.UserCharacterFavoriteReposit
 import com.example.demo.domain.conversation.repository.ConversationSessionRepository;
 import com.example.demo.domain.story.entity.Story;
 import com.example.demo.domain.story.repository.StoryRepository;
+import com.example.demo.domain.user.entity.EmailVerification;
 import com.example.demo.domain.user.entity.Token;
 import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.repository.EmailVerificationRepository;
 import com.example.demo.domain.user.repository.TokenRepository;
 import com.example.demo.domain.user.repository.UserRepository;
 import com.example.demo.domain.user.service.query.UserQueryService;
@@ -34,6 +36,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     private final UserRepository userRepository;
     private final TokenRepository tokenRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
     private final ConversationSessionRepository conversationSessionRepository;
     private final UserCharacterFavoriteRepository userCharacterFavoriteRepository;
     private final StoryRepository storyRepository;
@@ -118,10 +121,9 @@ public class UserCommandServiceImpl implements UserCommandService {
         if (isSignup) {
             // role=TEACHER(선생님)인 경우, 이메일 인증 확인 및 역활 전환
             if (role == User.UserGrade.TEACHER) {
-//                EmailVerification emailVerification = emailVerificationRepository
-//                        .findTopByUserIdAndVerifiedTrueOrderByVerifiedAtDesc(user.getId())
-//                        .filter(ev -> ev.getVerifiedAt().isAfter(LocalDateTime.now().minusMinutes(30)))
-//                        .orElseThrow(() -> new CustomException(ErrorStatus.EMAIL_NOT_VERIFIED));
+                emailVerificationRepository.findByUser(user)
+                        .filter(EmailVerification::isValid)
+                        .orElseThrow(() -> new CustomException(ErrorStatus.EMAIL_VERIFICATION_NOT_COMPLETED));
 
                 user.changeRole(User.UserGrade.TEACHER);
             }
@@ -157,10 +159,11 @@ public class UserCommandServiceImpl implements UserCommandService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
 
-        // 관련 엔티티 삭제 (대화, 토큰, 즐겨찾기)
+        // 관련 엔티티 삭제 (대화, 토큰, 즐겨찾기, 이메일 인증 내역)
         tokenRepository.deleteAllByUser(user);
         conversationSessionRepository.deleteAllByUser(user);
         userCharacterFavoriteRepository.deleteAllByUser(user);
+        emailVerificationRepository.deleteAllByUser(user);
 
         // 스토리의 user를 null로 세팅
         List<Story> stories = storyRepository.findByUser(user);

--- a/src/main/java/com/example/demo/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/demo/domain/user/service/command/UserCommandServiceImpl.java
@@ -101,18 +101,35 @@ public class UserCommandServiceImpl implements UserCommandService {
     }
 
     @Override
-    public LoginResponseDto.LoginResult loginUser(String tempCode) {
+    public LoginResponseDto.LoginResult loginUser(String tempCode, User.UserGrade role) {
 
-        // tempCode 로 토큰 조회 및 반환 정보 생성
+        // 1. tempCode 로 토큰 조회 및 반환 정보 생성
         LoginResponseDto.LoginResult loginResult = userQueryService.findTokenByTempCode(tempCode);
 
-        // accessToken 으로 사용자 조회
+        // 2. accessToken 으로 사용자 조회
         Token token = tokenRepository.findByAccessToken(loginResult.getAccessToken())
                 .orElseThrow(() -> new CustomException(ErrorStatus.USER_NOT_FOUND));
 
         User user = token.getUser();
 
-        // 사용자 활성화
+        // 3. 회원가입 여부 확인
+        boolean isSignup = !user.isAgreedToTerms();
+
+        if (isSignup) {
+            // role=TEACHER(선생님)인 경우, 이메일 인증 확인 및 역활 전환
+            if (role == User.UserGrade.TEACHER) {
+//                EmailVerification emailVerification = emailVerificationRepository
+//                        .findTopByUserIdAndVerifiedTrueOrderByVerifiedAtDesc(user.getId())
+//                        .filter(ev -> ev.getVerifiedAt().isAfter(LocalDateTime.now().minusMinutes(30)))
+//                        .orElseThrow(() -> new CustomException(ErrorStatus.EMAIL_NOT_VERIFIED));
+
+                user.changeRole(User.UserGrade.TEACHER);
+            }
+
+            user.setAgreedToTerms(true); // 회원가입 시 약관 동의로 설정
+        }
+
+        // 4. 사용자 활성화
         user.activate();
         userRepository.save(user);
 

--- a/src/main/java/com/example/demo/domain/user/web/controller/EmailVerificationController.java
+++ b/src/main/java/com/example/demo/domain/user/web/controller/EmailVerificationController.java
@@ -1,0 +1,55 @@
+package com.example.demo.domain.user.web.controller;
+
+import com.example.demo.apiPayload.ApiResponse;
+import com.example.demo.apiPayload.status.SuccessStatus;
+import com.example.demo.domain.user.service.command.EmailVerificationCommandService;
+import com.example.demo.domain.user.web.dto.EmailVerificationRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/permit/email")
+@RequiredArgsConstructor
+public class EmailVerificationController {
+
+    private final EmailVerificationCommandService emailVerificationCommandService;
+
+    @Operation(summary = "이메일 인증코드 발송",
+            description = """
+                    선생님 회원가입 시, 입력한 이메일로 인증코드를 발송합니다. **재요청 시 기존 인증 시도는 무효화됩니다.**
+                    
+                    - tempCode: 카카오 로그인 이후 받은 임시 토큰
+                    - email: 인증할 선생님 이메일
+                    """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+    })
+    @PostMapping("/send")
+    public ApiResponse<Void> sendEmailCode(
+            @RequestBody @Valid EmailVerificationRequest.Send request
+    ) {
+        emailVerificationCommandService.sendCode(request.getTempCode(), request.getEmail());
+        return ApiResponse.of(SuccessStatus._OK, null);
+    }
+
+    @Operation(summary = "이메일 인증코드 검증",
+            description = """
+            선생님 회원가입 시, 발송된 인증코드를 검증하여 이메일 인증을 완료합니다.
+            
+            - tempCode: 카카오 로그인 이후 받은 임시 토큰
+            - code: 이메일로 발송된 인증코드
+            """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+    })
+    @PostMapping("/verify")
+    public ApiResponse<Void> verifyEmailCode(
+            @RequestBody @Valid EmailVerificationRequest.Verification request
+    ) {
+        emailVerificationCommandService.verifyCode(request.getTempCode(), request.getCode());
+        return ApiResponse.of(SuccessStatus._OK, null);
+    }
+}

--- a/src/main/java/com/example/demo/domain/user/web/controller/UserLoginController.java
+++ b/src/main/java/com/example/demo/domain/user/web/controller/UserLoginController.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.user.web.controller;
 
 import com.example.demo.apiPayload.status.SuccessStatus;
+import com.example.demo.domain.user.entity.User;
 import com.example.demo.domain.user.service.command.UserCommandService;
 import com.example.demo.domain.user.web.dto.LoginResponseDto;
 import com.example.demo.apiPayload.ApiResponse;
@@ -17,17 +18,27 @@ public class UserLoginController {
 
     private final UserCommandService userCommandService;
 
-    @Operation(summary = "사용자 활성화 및 토큰 조회",
-            description = "tempToken 을 통해 현재 사용자를 활성화 상태로 변경하고, 새로운 액세스/리프레쉬 토큰을 반환합니다.")
+    @Operation(summary = "사용자 활성화 및 토큰 조회 (회원가입 겸 로그인)",
+            description = """
+                    tempToken 을 통해 현재 사용자를 활성화 상태로 변경하고, 새로운 액세스/리프레쉬 토큰을 반환합니다.\n\n
+                    **최초 호출(회원가입)**인지 **이후 호출(로그인)**인지는 서버가 자동으로 판별합니다.
+                    
+                    1. 회원가입 - role 파라미터로 학생/선생님 역할을 확정합니다.
+                        - role=BASIC (학생, 기본값) : 별도 인증 절차 없이 바로 가입 완료
+                        - role=TEACHER (선생님) : 가입 완료 전 이메일 인증이 반드시 선행되어야 합니다.
+                    
+                    2. 로그인 - role 파라미터는 무시되며, 기존에 확정된 역할 그대로 로그인이 진행됩니다.
+                    """)
     @Parameter(name = "tempCode", description = "사용자 활성화를 위한 임시 코드", required = true)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
     })
     @PatchMapping("/login")
     public ApiResponse<LoginResponseDto.LoginResult> activateUserAndGetToken(
-            @RequestParam("tempCode") String tempCode
+            @RequestParam("tempCode") String tempCode,
+            @RequestParam(value = "role", required = false) User.UserGrade role // role=TEACHER(선생님)일 때만 사용
     ) {
-        return ApiResponse.of(SuccessStatus._OK, userCommandService.loginUser(tempCode));
+        return ApiResponse.of(SuccessStatus._OK, userCommandService.loginUser(tempCode, role));
     }
 
 }

--- a/src/main/java/com/example/demo/domain/user/web/dto/EmailVerificationRequest.java
+++ b/src/main/java/com/example/demo/domain/user/web/dto/EmailVerificationRequest.java
@@ -1,0 +1,30 @@
+package com.example.demo.domain.user.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class EmailVerificationRequest {
+
+    @Getter
+    @NoArgsConstructor
+    public static class Send {
+        @NotBlank(message = "임시 토큰은 필수 입니다.")
+        private String tempCode;
+
+        @NotBlank(message = "이메일은 필수 입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        private String email;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Verification {
+        @NotBlank(message = "임시 토큰은 필수 입니다.")
+        private String tempCode;
+
+        @NotBlank(message = "인증 코드는 필수 입니다.")
+        private String code;
+    }
+}


### PR DESCRIPTION
## 🚀 변경사항
- user Entity에 teacher role 추가
- 로그인 로직에 회원가입 분기 추가 
  <img width="500"  alt="스크린샷 2026-08-13 오후 7 24 19" src="https://github.com/user-attachments/assets/2501c9a9-a93f-48a0-a795-cc511889802f" />
- 로그인 후 사용자 활성화 시, 약관동의 설정 부분 제거 (회원가입에서 1번만 처리)
  <img width="400" alt="스크린샷 2026-08-13 오후 7 27 30" src="https://github.com/user-attachments/assets/4a35c225-274d-4421-8029-9f475c5e133a" />
- 이메일 인증코드 발송 및 검증 api 구현(메일 로직 연결 X)


## 🔗 관련 이슈
- Closes #70 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료